### PR TITLE
Fix docker/README.md to refer to xks-proxy:v2.0.0 +

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## aws-kms-xks-proxy
 
-This package provides a reference implementation of the `AWS KMS External Keystore (XKS) Proxy API` for direct usage or further adaptation by external customers against any [Hardware Security Module](https://en.wikipedia.org/wiki/Hardware_security_module) (HSM) that supports [PKCS#11 v2.40](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html).
+This package provides a sample implementation of the `AWS KMS External Keystore (XKS) Proxy API` for reference by external customers against any [Hardware Security Module](https://en.wikipedia.org/wiki/Hardware_security_module) (HSM) that supports [PKCS#11 v2.40](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html).
 
 The current implementation is written in [Rust](https://www.rust-lang.org/) and is known to work with the following types of HSM:
 * `LunaSA 7.4.0` (via Thales eLab)

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,25 +18,25 @@ This is an outline of how to build a docker image for `xks-proxy`, including inf
 1. Adjust [Dockerfile](Dockerfile) as needed.
 1. Build a docker image for `xks-proxy`:
 
-        docker build -t xks-proxy:v1.0.1 .
+        docker build -t xks-proxy:v2.0.0 .
 1. Save the image to a tar file, if it needs to be exported/shared:
 
-        docker save -o xks-proxy-docker-v1.0.1.tar xks-proxy:v1.0.1
-1. Compress `xks-proxy-docker-v1.0.1.tar` into `xks-proxy-docker-v1.0.1.tar.xz` if necessary:
+        docker save -o xks-proxy-docker-v2.0.0.tar xks-proxy:v2.0.0
+1. Compress `xks-proxy-docker-v2.0.0.tar` into `xks-proxy-docker-v2.0.0.tar.xz` if necessary:
 
-        xz -z -0 xks-proxy-docker-v1.0.1.tar
+        xz -z -0 xks-proxy-docker-v2.0.0.tar
 
 ## How to run `xks-proxy` in a docker container?
 
-1. Decompress `xks-proxy-docker-v1.0.1.tar.xz` to `xks-proxy-docker-v1.0.1.tar` if necessary:
+1. Decompress `xks-proxy-docker-v2.0.0.tar.xz` to `xks-proxy-docker-v2.0.0.tar` if necessary:
 
-       xz -d xks-proxy-docker-v1.0.1.tar.xz
+       xz -d xks-proxy-docker-v2.0.0.tar.xz
 1. Load the docker image if necessary:
 
-       docker load -i xks-proxy-docker-v1.0.1.tar
+       docker load -i xks-proxy-docker-v2.0.0.tar
 1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `8000` on the running host:
 
-        docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:v1.0.1
+        docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:v2.0.0
 1. Now you can access it at
 `http://<your hostname>/example/uri/path/prefix/kms/xks/v1`
 or whatever URI path you've configured in `settings.toml`.
@@ -45,7 +45,7 @@ or whatever URI path you've configured in `settings.toml`.
 
 * Remove the `xks-proxy` docker image:
 
-        docker rmi xks-proxy:v1.0.1
+        docker rmi xks-proxy:v2.0.0
 * Exec into the `xks-proxy` docker container:
 
         docker exec -it xks-proxy bash
@@ -57,7 +57,7 @@ or whatever URI path you've configured in `settings.toml`.
         docker container ls
 * Ping `xks-proxy` running in docker container
 
-        # should get back a "pong from xks-proxy v1.0.1" response
+        # should get back a "pong from xks-proxy v2.0.0" response
         curl http://localhost/ping
 * Follow the log of the running `xks-proxy` in the docker container
 


### PR DESCRIPTION
Modify REAMDE.md to clarify this is a sample implementation.

*Issue #, if available:*

*Description of changes:*
1. Fix docker/README.md to refer to xks-proxy:v2.0.0
1. Modify REAMDE.md to clarify this is a sample implementation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
