### PR TITLE
Support configurable interval to send TCP keepalive probes + Change to use port 80 as sample instead of port 8000 + Upgrade to v2.0.1

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -18,25 +18,25 @@ This is an outline of how to build a docker image for `xks-proxy`, including inf
 1. Adjust [Dockerfile](Dockerfile) as needed.
 1. Build a docker image for `xks-proxy`:
 
-        docker build -t xks-proxy:v2.0.0 .
+        docker build -t xks-proxy:v2.0.1 .
 1. Save the image to a tar file, if it needs to be exported/shared:
 
-        docker save -o xks-proxy-docker-v2.0.0.tar xks-proxy:v2.0.0
-1. Compress `xks-proxy-docker-v2.0.0.tar` into `xks-proxy-docker-v2.0.0.tar.xz` if necessary:
+        docker save -o xks-proxy-docker-v2.0.1.tar xks-proxy:v2.0.1
+1. Compress `xks-proxy-docker-v2.0.1.tar` into `xks-proxy-docker-v2.0.1.tar.xz` if necessary:
 
-        xz -z -0 xks-proxy-docker-v2.0.0.tar
+        xz -z -0 xks-proxy-docker-v2.0.1.tar
 
 ## How to run `xks-proxy` in a docker container?
 
-1. Decompress `xks-proxy-docker-v2.0.0.tar.xz` to `xks-proxy-docker-v2.0.0.tar` if necessary:
+1. Decompress `xks-proxy-docker-v2.0.1.tar.xz` to `xks-proxy-docker-v2.0.1.tar` if necessary:
 
-       xz -d xks-proxy-docker-v2.0.0.tar.xz
+       xz -d xks-proxy-docker-v2.0.1.tar.xz
 1. Load the docker image if necessary:
 
-       docker load -i xks-proxy-docker-v2.0.0.tar
-1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `8000` on the running host:
+       docker load -i xks-proxy-docker-v2.0.1.tar
+1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `80` on the running host:
 
-        docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:v2.0.0
+        docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:v2.0.1
 1. Now you can access it at
 `http://<your hostname>/example/uri/path/prefix/kms/xks/v1`
 or whatever URI path you've configured in `settings.toml`.
@@ -45,7 +45,7 @@ or whatever URI path you've configured in `settings.toml`.
 
 * Remove the `xks-proxy` docker image:
 
-        docker rmi xks-proxy:v2.0.0
+        docker rmi xks-proxy:v2.0.1
 * Exec into the `xks-proxy` docker container:
 
         docker exec -it xks-proxy bash
@@ -57,7 +57,7 @@ or whatever URI path you've configured in `settings.toml`.
         docker container ls
 * Ping `xks-proxy` running in docker container
 
-        # should get back a "pong from xks-proxy v2.0.0" response
+        # should get back a "pong from xks-proxy v2.0.1" response
         curl http://localhost/ping
 * Follow the log of the running `xks-proxy` in the docker container
 

--- a/rpmspec/xks-proxy.spec
+++ b/rpmspec/xks-proxy.spec
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Name:           xks-proxy
-Version:        2.0.0
+Version:        2.0.1
 
 Release:        0%{?dist}
 Summary:        AWS External Keystore (XKS) Proxy Service
@@ -45,6 +45,8 @@ systemctl disable xks-proxy.service
 systemctl disable xks-proxy_cleanlogs.timer
 
 %changelog
+* Sun Sep 11 2022 Hanson Char <hchar@amazon.com> - 2.0.1
+- Support configurable interval to send TCP keepalive probes
 * Thu Sep 08 2022 Hanson Char <hchar@amazon.com> - 2.0.0
 - Rename sigv4_access_id to sigv4_access_key_id and sigv4_secret_key to sigv4_secret_access_key
 * Thu Aug 25 2022 Hanson Char <hchar@amazon.com> - 1.0.1

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "xks-proxy"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2018"
 publish = false
 

--- a/xks-axum/configuration/settings.toml
+++ b/xks-axum/configuration/settings.toml
@@ -7,11 +7,15 @@
 
 [server]
 ip = "0.0.0.0"
-port = 8000
+port = 80
 region = "us-east-1"
 service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
+
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
 
 [tracing]
 # Used to control logging to stdout

--- a/xks-axum/configuration/settings_cloudhsm.toml
+++ b/xks-axum/configuration/settings_cloudhsm.toml
@@ -5,11 +5,15 @@
 # It assumes you have installed and set up the necessary AWS CloudHSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 8000
+port = 80
 region = "us-east-2"
 service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
+
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
 
 [tracing]
 # Used to control logging to stdout

--- a/xks-axum/configuration/settings_docker.toml
+++ b/xks-axum/configuration/settings_docker.toml
@@ -12,6 +12,10 @@ service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
 
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
+
 [tracing]
 # Used to control logging to stdout
 is_stdout_writer_enabled = true

--- a/xks-axum/configuration/settings_luna.toml
+++ b/xks-axum/configuration/settings_luna.toml
@@ -5,11 +5,15 @@
 # It assumes you have installed and set up the necessary Thales Luna HSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 8000
+port = 80
 region = "us-east-1"
 service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
+
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
 
 [tracing]
 # Used to control logging to stdout

--- a/xks-axum/configuration/settings_softhsmv2.toml
+++ b/xks-axum/configuration/settings_softhsmv2.toml
@@ -6,11 +6,15 @@
 # /usr/local/lib/softhsm/libsofthsm2.so
 [server]
 ip = "0.0.0.0"
-port = 8000
+port = 80
 region = "us-east-1"
 service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
+
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
 
 [tracing]
 # Used to control logging to stdout

--- a/xks-axum/configuration/settings_softhsmv2_osx.toml
+++ b/xks-axum/configuration/settings_softhsmv2_osx.toml
@@ -7,11 +7,15 @@
 # 2. installed pkcs11-logger, and have placed its OSX dynamic library at /usr/local/lib/pkcs11-logger-x64.dylib
 [server]
 ip = "0.0.0.0"
-port = 8000
+port = 80
 region = "us-east-1"
 service = "kms-xks-proxy"
 # Optional configuration of ciphertext metadata in base 64 encoding
 # ciphertext_metadata_b64 = "djAuMC4x"
+
+# Optional configuration of how often to send TCP keepalive probes
+# No configuration means TCP keepalive probes is disabled.
+tcp_keepalive_secs = 60
 
 [tracing]
 # Used to control logging to stdout

--- a/xks-axum/src/settings.rs
+++ b/xks-axum/src/settings.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
+use std::time::Duration;
 use std::{env, fs};
 
 use lazy_static::lazy_static;
 use serde_derive::Deserialize;
+use serde_with::{serde_as, DurationSeconds};
 use tracing::instrument;
 use tracing_appender::rolling::Rotation;
 
@@ -41,13 +43,17 @@ pub struct Settings {
     pub external_key_stores: Vec<ExternalKeyStore>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[serde_as]
+#[derive(Deserialize, Debug, Clone)]
 pub struct ServerConfig {
     pub ip: String,
     pub port: u16,
     pub region: String,
     pub service: String,
     pub ciphertext_metadata_b64: Option<String>,
+    // https://stackoverflow.com/questions/70184303/how-to-serialize-and-deserialize-chronoduration
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
+    pub tcp_keepalive_secs: Option<Duration>,
 }
 
 #[non_exhaustive]


### PR DESCRIPTION
*Issue #, if available:*

I recently observed the following error when running the xks-proxy against a CloudHSM:
```
ERROR                 main hyper::server::tcp: accept error: Too many open files (os error 24)
```
Using `lsof`, I saw
```bash
sudo lsof -p 106586 | grep TCP | wc -l
1006

sudo lsof -p 106586 | grep TCP | grep ESTABLISHED | wc -l
1005
```
Apparently, the tcp keep-alive timeout is disabled by default in hyper:

> https://github.com/hyperium/hyper/blob/0.14.x/src/server/tcp.rs#L66-L74

*Description of changes:*

1. Support configurable interval to send TCP keepalive probes
1. Change to use port 80 as sample instead of port 8000
1. Upgrade to v2.0.1

*Testing:*

Testing with a 60 second interval to send TCP keepalive probes is in progress.  
```
2022-09-12T00:14:47.563391Z  INFO main xks_proxy: v2.0.1 listening on 0.0.0.0:443
2022-09-12T00:14:47.564184Z  INFO main xks_proxy: TCP keepalive interval is set to 60 seconds
```
Will see if this change actually fixes the issue by running the patched server on the host that exhibited this failure before for a day or two.
```bash
watch `sudo lsof -p 129360 | grep TCP | grep ESTABLISHED | wc -l && sudo lsof -p 129360 | grep TCP | sort -k9 | grep ESTABLISHED`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
