### PR TITLE
replace action-rs with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,18 +20,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: cargo fmt --check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml --all -- --check
+      - name: Check format
+        run: cargo fmt --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml --all -- --check
 
   test-n-clippy:
     name: Unit Test and Clippy
@@ -42,23 +34,13 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
-    - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml
+    - name: Unit Test
+      run: cargo test --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml
 
     - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml
+      run: cargo clippy --manifest-path=${{ env.PROJECT_DIR }}/Cargo.toml
 
   # check-on-macos:
 
@@ -105,14 +87,9 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install other dependencies
-      # run: sudo apt-get install -y rpm rpmlint alien
       run: sudo apt-get install -y rpm alien
 
     - name: Build xks-proxy rpm and deb


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace the Github action for Rust toolchain with a better alternative.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

