### PR TITLE
Hyper 0.14.22 has been released

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -66,7 +66,6 @@ serial_test_derive = "0.9"
 pkcs11 = { path = "rust-pkcs11" }
 
 # Patch to enable configuration of full TCP keepalive parameters
-hyper = { git = "https://github.com/hyperium/hyper.git", branch = "0.14.x" }
 axum-server = { path = "axum-server" }
 
 [profile.dev]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We can now refer to the official release of hyper instead of pointing to the branch as hyper 0.14.22 has been released with the TCP keep-alive changes that we depend upon.

Passed CI/CD: https://github.com/hansonchar/aws-kms-xks-proxy/actions/runs/3379269115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

