### PR TITLE
Always return ValidationException upon invalid JSON payload,

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -178,11 +178,11 @@ jobs:
     - name: Build docker image
       run: |
         docker build -t xks-proxy:latest .
-        docker save -o xks-proxy-docker-v3.1.0-${{ matrix.config.arch }}.tar xks-proxy:latest
-        xz -z -0 xks-proxy-docker-v3.1.0-${{ matrix.config.arch }}.tar
+        docker save -o xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar xks-proxy:latest
+        xz -z -0 xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar
 
     - name: Upload docker image
       uses: actions/upload-artifact@v3
       with:
-        name: xks-proxy-docker-v3.1.0-${{ matrix.config.arch }}.tar.xz
-        path: ./xks-proxy-docker-v3.1.0-${{ matrix.config.arch }}.tar.xz
+        name: xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz
+        path: ./xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl localhost/ping
 ```
 You should see the response:
 
->pong from xks-proxy v3.1.0
+>pong from xks-proxy v3.1.1
 
 which indicates the server is now up and running.  You can monitor the logs with:
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,19 +14,19 @@ An outline and some examples on how to build a docker image for `xks-proxy` and 
         docker build -t xks-proxy:latest .
 1. Save the image to a tar file, if it needs to be exported/shared:
 
-        docker save -o xks-proxy-docker-v3.1.0.tar xks-proxy:latest
-1. Compress `xks-proxy-docker-v3.1.0.tar` into `xks-proxy-docker-v3.1.0.tar.xz` if necessary:
+        docker save -o xks-proxy-docker-v3.1.1.tar xks-proxy:latest
+1. Compress `xks-proxy-docker-v3.1.1.tar` into `xks-proxy-docker-v3.1.1.tar.xz` if necessary:
 
-        xz -z -0 xks-proxy-docker-v3.1.0.tar
+        xz -z -0 xks-proxy-docker-v3.1.1.tar
 
 ## How to run `xks-proxy` in a docker container?
 
-1. Decompress `xks-proxy-docker-v3.1.0.tar.xz` to `xks-proxy-docker-v3.1.0.tar` if necessary:
+1. Decompress `xks-proxy-docker-v3.1.1.tar.xz` to `xks-proxy-docker-v3.1.1.tar` if necessary:
 
-       xz -d xks-proxy-docker-v3.1.0.tar.xz
+       xz -d xks-proxy-docker-v3.1.1.tar.xz
 1. Load the docker image if necessary:
 
-       docker load -i xks-proxy-docker-v3.1.0.tar
+       docker load -i xks-proxy-docker-v3.1.1.tar
 1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `80` on the running host:
 
         docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:latest
@@ -50,7 +50,7 @@ or whatever URI path you've configured in `settings.toml`.
         docker container ls
 * Ping `xks-proxy` running in docker container
 
-        # should get back a "pong from xks-proxy v3.1.0" response
+        # should get back a "pong from xks-proxy v3.1.1" response
         curl http://localhost/ping
 * Follow the log of the running `xks-proxy` in the docker container
 

--- a/rpmspec/xks-proxy.spec
+++ b/rpmspec/xks-proxy.spec
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Name:           xks-proxy
-Version:        3.1.0
+Version:        3.1.1
 
 Release:        0%{?dist}
 Summary:        AWS External Keystore (XKS) Proxy Service
@@ -45,6 +45,8 @@ systemctl disable xks-proxy.service
 systemctl disable xks-proxy_cleanlogs.timer
 
 %changelog
+* Tue Nov 22 2022 Hanson Char <hchar@amazon.com> - 3.1.1
+- Always return ValidationException upon invalid JSON payload
 * Wed Nov 09 2022 Hanson Char <hchar@amazon.com> - 3.1.0
 - Always enable http ping for load balancer
 * Wed Sep 21 2022 Hanson Char <hchar@amazon.com> - 3.0.0

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "xks-proxy"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2018"
 publish = false
 

--- a/xks-axum/src/xks_proxy/handlers/mod.rs
+++ b/xks-axum/src/xks_proxy/handlers/mod.rs
@@ -469,9 +469,7 @@ where
                     JsonRejection::MissingJsonContentType(err) => {
                         ValidationException.as_axum_error(err.to_string())
                     }
-                    err => {
-                        InternalException.as_axum_error(format!("Unknown internal error: {err}"))
-                    }
+                    err => ValidationException.as_axum_error(format!("Unknown JSON error: {err}")),
                 })
             }
         }


### PR DESCRIPTION
upgrading to v3.1.1

*Issue #, if available:*

*Description of changes:*

There were cases where an invalid JSON payload such as the inclusion of `"plaintext": " %20,` that would trigger a response of 500, `InternalException`.  This PR fixes that to return 400, `ValidationException`.

*Testing:*

Tested locally using docker with the problematic payload, and now 400 is returned instead of 500.

See [sample run](https://github.com/hansonchar/aws-kms-xks-proxy/actions/runs/3526151565) of CI/CD workflow for this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

