### PR TITLE
Include git hash in version + remove noise if command alien is not found

### DIFF
--- a/xks-axum/src/main.rs
+++ b/xks-axum/src/main.rs
@@ -49,9 +49,13 @@ const URI_PATH_DECRYPT: &str = concatcp!(KMS_XKS_V1_PATH, "keys/:key_id/", DECRY
 const URI_PATH_HEALTH: &str = concatcp!(KMS_XKS_V1_PATH, HEALTH);
 // Used for ALB ping
 const URI_PATH_PING: &str = "/ping";
-const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
-const PING_RESPONSE: &str = concatcp!("pong from ", CARGO_PKG_NAME, " v", CARGO_PKG_VERSION, "\n");
+
+const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_HASH: &str = if let Some(hash) = option_env!("GIT_HASH") { hash } else { "unknown" };
+const VERSION: &str = concatcp!(CARGO_PKG_VERSION, "-", GIT_HASH);
+
+const PING_RESPONSE: &str = concatcp!("pong from ", CARGO_PKG_NAME, " v", VERSION, "\n");
 
 #[tokio::main]
 async fn main() {
@@ -145,7 +149,7 @@ async fn proxy_server(server_config: &ServerConfig) {
         .parse()
         .unwrap_or_else(|_| panic!("unable to parse server ip address {}", server_config.ip));
     let socket_addr = SocketAddr::from((ip_addr, server_config.port));
-    tracing::info!("v{CARGO_PKG_VERSION} listening on {socket_addr} for traffic");
+    tracing::info!("v{VERSION} listening on {socket_addr} for traffic");
     tracing::info!(tcp_keepalive = ?server_config.tcp_keepalive, "TCP keepalive");
     let ka_config = &server_config.tcp_keepalive;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change would provides not only the Cargo version number during runtime, but also the specific git commit that was compiled.

Example:

When starting up the server:
```
INFO tokio-runtime-worker xks_proxy: v3.1.1-6012b14 listening on 0.0.0.0:443 for traffic
```

Upon ping:
```
$ curl localhost/ping
pong from xks-proxy v3.1.1-6012b14
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

