### PR TITLE
Enable the use of SoftHSMv2 in a concurrent environment without crashing, upgrading to v3.2.0

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -178,11 +178,11 @@ jobs:
     - name: Build docker image
       run: |
         docker build -t xks-proxy:latest .
-        docker save -o xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar xks-proxy:latest
-        xz -z -0 xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar
+        docker save -o xks-proxy-docker-v3.2.0-${{ matrix.config.arch }}.tar xks-proxy:latest
+        xz -z -0 xks-proxy-docker-v3.2.0-${{ matrix.config.arch }}.tar
 
     - name: Upload docker image
       uses: actions/upload-artifact@v3
       with:
-        name: xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz
-        path: ./xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz
+        name: xks-proxy-docker-v3.2.0-${{ matrix.config.arch }}.tar.xz
+        path: ./xks-proxy-docker-v3.2.0-${{ matrix.config.arch }}.tar.xz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl localhost/ping
 ```
 You should see the response:
 
->pong from xks-proxy v3.1.1
+>pong from xks-proxy v3.2.0
 
 which indicates the server is now up and running.  You can monitor the logs with:
 ```bash
@@ -90,7 +90,7 @@ make
 To install the generated [RPM](https://en.wikipedia.org/wiki/RPM_Package_Manager) on a `Centos Linux x86_64` platform:
 ```bash
 # For example
-sudo yum install -y xks-proxy-3.1.1-0.el7.x86_64.rpm
+sudo yum install -y xks-proxy-3.2.0-0.el7.x86_64.rpm
 ```
 
 ### Configuration

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,19 +14,19 @@ An outline and some examples on how to build a docker image for `xks-proxy` and 
         docker build -t xks-proxy:latest .
 1. Save the image to a tar file, if it needs to be exported/shared:
 
-        docker save -o xks-proxy-docker-v3.1.1.tar xks-proxy:latest
-1. Compress `xks-proxy-docker-v3.1.1.tar` into `xks-proxy-docker-v3.1.1.tar.xz` if necessary:
+        docker save -o xks-proxy-docker-v3.2.0.tar xks-proxy:latest
+1. Compress `xks-proxy-docker-v3.2.0.tar` into `xks-proxy-docker-v3.2.0.tar.xz` if necessary:
 
-        xz -z -0 xks-proxy-docker-v3.1.1.tar
+        xz -z -0 xks-proxy-docker-v3.2.0.tar
 
 ## How to run `xks-proxy` in a docker container?
 
-1. Decompress `xks-proxy-docker-v3.1.1.tar.xz` to `xks-proxy-docker-v3.1.1.tar` if necessary:
+1. Decompress `xks-proxy-docker-v3.2.0.tar.xz` to `xks-proxy-docker-v3.2.0.tar` if necessary:
 
-       xz -d xks-proxy-docker-v3.1.1.tar.xz
+       xz -d xks-proxy-docker-v3.2.0.tar.xz
 1. Load the docker image if necessary:
 
-       docker load -i xks-proxy-docker-v3.1.1.tar
+       docker load -i xks-proxy-docker-v3.2.0.tar
 1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `80` on the running host:
 
         docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:latest
@@ -50,7 +50,7 @@ or whatever URI path you've configured in `settings.toml`.
         docker container ls
 * Ping `xks-proxy` running in docker container
 
-        # should get back a "pong from xks-proxy v3.1.1" response
+        # should get back a "pong from xks-proxy v3.2.0" response
         curl http://localhost/ping
 * Follow the log of the running `xks-proxy` in the docker container
 

--- a/rpmspec/xks-proxy.spec
+++ b/rpmspec/xks-proxy.spec
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Name:           xks-proxy
-Version:        3.1.1
+Version:        3.2.0
 
 Release:        0%{?dist}
 Summary:        AWS External Keystore (XKS) Proxy Service
@@ -45,6 +45,19 @@ systemctl disable xks-proxy.service
 systemctl disable xks-proxy_cleanlogs.timer
 
 %changelog
+* Mon Nov 28 2022 Hanson Char <hchar@amazon.com> - 3.2.0
+- Supports can_close_session HSM capability
+- Initialize pkcs11 context with lock functions and upon failure would
+  retry pkcs11 initialization without callback functions
+- Fix memory corruption bugs in pkcs11 crate in context initialization
+- Fix doc inconsistency
+- Log pool exhaustion as a warning instead of info
+- Avoid removing session from pool unnecessarily
+- Always attempt to login when creating a new session
+- Respond with InternalException instead of KeyNotFoundException upon CKR_GENERAL_ERROR.
+- Treat both CKR_DEVICE_ERROR and CKR_GENERAL_ERROR as fatal so as
+  to reset the pkcs11 context.
+- Include git hash in version + remove noise if command alien is not found
 * Tue Nov 22 2022 Hanson Char <hchar@amazon.com> - 3.1.1
 - Always return ValidationException upon invalid JSON payload
 * Wed Nov 09 2022 Hanson Char <hchar@amazon.com> - 3.1.0

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "xks-proxy"
-version = "3.1.1"
+version = "3.2.0"
 edition = "2018"
 publish = false
 

--- a/xks-axum/configuration/settings.toml
+++ b/xks-axum/configuration/settings.toml
@@ -48,8 +48,7 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
-is_tls_enabled = true
+is_tls_enabled = false
 is_mtls_enabled = false
 
 # (Optional) secondary authorization used
@@ -122,3 +121,9 @@ max_aad_in_base64 = 16384
 # So the solution is to use SoftHSMv2 to generate random for the IV.
 can_generate_iv = false
 is_zero_iv_required = false
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = false

--- a/xks-axum/configuration/settings_cloudhsm.toml
+++ b/xks-axum/configuration/settings_cloudhsm.toml
@@ -5,7 +5,7 @@
 # It assumes you have installed and set up the necessary AWS CloudHSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 80
+port = 443
 # (Optional) port used for http ping.  Defaults to 80.
 # port_http_ping = 80
 region = "us-east-2"
@@ -46,7 +46,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = true
 is_mtls_enabled = false
 
@@ -118,3 +117,9 @@ max_aad_in_base64 = 16384
 # CloudHSM always generate IV but requires the input IV to be all zeros.
 can_generate_iv = true
 is_zero_iv_required = true
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = true

--- a/xks-axum/configuration/settings_docker.toml
+++ b/xks-axum/configuration/settings_docker.toml
@@ -47,7 +47,6 @@ level = "DEBUG"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = false
 is_mtls_enabled = false
 
@@ -121,3 +120,9 @@ max_aad_in_base64 = 16384
 # So the solution is to use SoftHSMv2 to generate random for the IV.
 can_generate_iv = false
 is_zero_iv_required = false
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = false

--- a/xks-axum/configuration/settings_luna.toml
+++ b/xks-axum/configuration/settings_luna.toml
@@ -5,7 +5,7 @@
 # It assumes you have installed and set up the necessary Thales Luna HSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 80
+port = 443
 # (Optional) port used for http ping.  Defaults to 80.
 # port_http_ping = 80
 region = "us-east-1"
@@ -46,7 +46,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = true
 is_mtls_enabled = false
 
@@ -121,3 +120,9 @@ max_aad_in_base64 = 16384
 # after the authentication tag.
 can_generate_iv = true
 is_zero_iv_required = false
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = true

--- a/xks-axum/configuration/settings_softhsmv2.toml
+++ b/xks-axum/configuration/settings_softhsmv2.toml
@@ -47,8 +47,7 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
-is_tls_enabled = true
+is_tls_enabled = false
 is_mtls_enabled = false
 
 # (Optional) secondary authorization used
@@ -121,3 +120,9 @@ max_aad_in_base64 = 16384
 # So the solution is to use SoftHSMv2 to generate random for the IV.
 can_generate_iv = false
 is_zero_iv_required = false
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = false

--- a/xks-axum/configuration/settings_softhsmv2_osx.toml
+++ b/xks-axum/configuration/settings_softhsmv2_osx.toml
@@ -48,7 +48,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = false
 is_mtls_enabled = false
 
@@ -123,3 +122,9 @@ max_aad_in_base64 = 16384
 # So the solution is to use SoftHSMv2 to generate random for the IV.
 can_generate_iv = false
 is_zero_iv_required = false
+
+# This should be always true in theory.
+# In practice, enabling this when SoftHSMv2 2.6.1 is in use would lead to crashes
+# in a concurrent environment.
+# Defaults to true if not specified.
+can_close_session = false

--- a/xks-axum/rust-pkcs11/src/lib.rs
+++ b/xks-axum/rust-pkcs11/src/lib.rs
@@ -428,11 +428,11 @@ impl Ctx {
         }
     }
 
-    pub fn initialize(&mut self, init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
+    pub fn initialize(&mut self, mut init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
         self.not_initialized()?;
         // if no args are specified, library expects NULL
-        let init_args = match init_args {
-            Some(mut args) => &mut args,
+        let init_args = match &mut init_args {
+            Some(args) => args,
             None => ptr::null_mut(),
         };
         match (self.C_Initialize)(init_args) {

--- a/xks-axum/src/settings.rs
+++ b/xks-axum/src/settings.rs
@@ -143,6 +143,13 @@ pub struct LimitsConfig {
 pub struct HsmCapabilitiesConfig {
     pub can_generate_iv: bool,
     pub is_zero_iv_required: bool,
+    pub can_close_session: Option<bool>,
+}
+
+impl HsmCapabilitiesConfig {
+    pub fn can_close_session(&self) -> bool {
+        self.can_close_session.unwrap_or(true)
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enable the use of SoftHSMv2 in a concurrent environment without crashing, upgrading to v3.2.0
1. Supports `can_close_session` HSM capability.  (For SoftHSMv2, this flag must be set to `false`.)
1. Initialize pkcs11 context with lock functions and upon failure would retry pkcs11 initialization without callback functions
1. Fix memory corruption bugs in pkcs11 crate in context initialization
1. Mark `C_Initialize`, `Ctx::new_and_initialize` and `Ctx::initialize` as unsafe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

