### PR TITLE
Enable the use of SoftHSMv2 in a concurrent environment without crashing, upgrading to v3.1.2

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -178,11 +178,11 @@ jobs:
     - name: Build docker image
       run: |
         docker build -t xks-proxy:latest .
-        docker save -o xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar xks-proxy:latest
-        xz -z -0 xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar
+        docker save -o xks-proxy-docker-v3.1.2-${{ matrix.config.arch }}.tar xks-proxy:latest
+        xz -z -0 xks-proxy-docker-v3.1.2-${{ matrix.config.arch }}.tar
 
     - name: Upload docker image
       uses: actions/upload-artifact@v3
       with:
-        name: xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz
-        path: ./xks-proxy-docker-v3.1.1-${{ matrix.config.arch }}.tar.xz
+        name: xks-proxy-docker-v3.1.2-${{ matrix.config.arch }}.tar.xz
+        path: ./xks-proxy-docker-v3.1.2-${{ matrix.config.arch }}.tar.xz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl localhost/ping
 ```
 You should see the response:
 
->pong from xks-proxy v3.1.1
+>pong from xks-proxy v3.1.2
 
 which indicates the server is now up and running.  You can monitor the logs with:
 ```bash
@@ -90,7 +90,7 @@ make
 To install the generated [RPM](https://en.wikipedia.org/wiki/RPM_Package_Manager) on a `Centos Linux x86_64` platform:
 ```bash
 # For example
-sudo yum install -y xks-proxy-3.1.1-0.el7.x86_64.rpm
+sudo yum install -y xks-proxy-3.1.2-0.el7.x86_64.rpm
 ```
 
 ### Configuration

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,19 +14,19 @@ An outline and some examples on how to build a docker image for `xks-proxy` and 
         docker build -t xks-proxy:latest .
 1. Save the image to a tar file, if it needs to be exported/shared:
 
-        docker save -o xks-proxy-docker-v3.1.1.tar xks-proxy:latest
-1. Compress `xks-proxy-docker-v3.1.1.tar` into `xks-proxy-docker-v3.1.1.tar.xz` if necessary:
+        docker save -o xks-proxy-docker-v3.1.2.tar xks-proxy:latest
+1. Compress `xks-proxy-docker-v3.1.2.tar` into `xks-proxy-docker-v3.1.2.tar.xz` if necessary:
 
-        xz -z -0 xks-proxy-docker-v3.1.1.tar
+        xz -z -0 xks-proxy-docker-v3.1.2.tar
 
 ## How to run `xks-proxy` in a docker container?
 
-1. Decompress `xks-proxy-docker-v3.1.1.tar.xz` to `xks-proxy-docker-v3.1.1.tar` if necessary:
+1. Decompress `xks-proxy-docker-v3.1.2.tar.xz` to `xks-proxy-docker-v3.1.2.tar` if necessary:
 
-       xz -d xks-proxy-docker-v3.1.1.tar.xz
+       xz -d xks-proxy-docker-v3.1.2.tar.xz
 1. Load the docker image if necessary:
 
-       docker load -i xks-proxy-docker-v3.1.1.tar
+       docker load -i xks-proxy-docker-v3.1.2.tar
 1. Run `xks-proxy` in a docker container exposing port `80` (of the container) as port `80` on the running host:
 
         docker run --name xks-proxy -d -p 0.0.0.0:80:80 xks-proxy:latest
@@ -50,7 +50,7 @@ or whatever URI path you've configured in `settings.toml`.
         docker container ls
 * Ping `xks-proxy` running in docker container
 
-        # should get back a "pong from xks-proxy v3.1.1" response
+        # should get back a "pong from xks-proxy v3.1.2" response
         curl http://localhost/ping
 * Follow the log of the running `xks-proxy` in the docker container
 

--- a/rpmspec/xks-proxy.spec
+++ b/rpmspec/xks-proxy.spec
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Name:           xks-proxy
-Version:        3.1.1
+Version:        3.1.2
 
 Release:        0%{?dist}
 Summary:        AWS External Keystore (XKS) Proxy Service
@@ -45,6 +45,18 @@ systemctl disable xks-proxy.service
 systemctl disable xks-proxy_cleanlogs.timer
 
 %changelog
+* Mon Nov 28 2022 Hanson Char <hchar@amazon.com> - 3.1.2
+- Initialize pkcs11 context with lock functions and upon failure would
+  retry pkcs11 initialization without callback functions
+- Fix memory corruption bugs in pkcs11 crate in context initialization
+- Fix bug in closing pkcs11 session
+- Mark Ctx::new_and_initialize and Ctx::initialize as unsafe
+- Fix doc inconsistency
+- Log pool exhaustion as a warning instead of info
+- Avoid removing session from pool unnecessarily
+- Always attempt to login when creating a new session
+- Respond with InternalException instead of KeyNotFoundException upon CKR_GENERAL_ERROR.
+- Include git hash in version + remove noise if command alien is not found
 * Tue Nov 22 2022 Hanson Char <hchar@amazon.com> - 3.1.1
 - Always return ValidationException upon invalid JSON payload
 * Wed Nov 09 2022 Hanson Char <hchar@amazon.com> - 3.1.0

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "xks-proxy"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2018"
 publish = false
 

--- a/xks-axum/configuration/settings.toml
+++ b/xks-axum/configuration/settings.toml
@@ -48,8 +48,7 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
-is_tls_enabled = true
+is_tls_enabled = false
 is_mtls_enabled = false
 
 # (Optional) secondary authorization used

--- a/xks-axum/configuration/settings_cloudhsm.toml
+++ b/xks-axum/configuration/settings_cloudhsm.toml
@@ -5,7 +5,7 @@
 # It assumes you have installed and set up the necessary AWS CloudHSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 80
+port = 443
 # (Optional) port used for http ping.  Defaults to 80.
 # port_http_ping = 80
 region = "us-east-2"
@@ -46,7 +46,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = true
 is_mtls_enabled = false
 

--- a/xks-axum/configuration/settings_docker.toml
+++ b/xks-axum/configuration/settings_docker.toml
@@ -47,7 +47,6 @@ level = "DEBUG"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = false
 is_mtls_enabled = false
 

--- a/xks-axum/configuration/settings_luna.toml
+++ b/xks-axum/configuration/settings_luna.toml
@@ -5,7 +5,7 @@
 # It assumes you have installed and set up the necessary Thales Luna HSM client side library.
 [server]
 ip = "0.0.0.0"
-port = 80
+port = 443
 # (Optional) port used for http ping.  Defaults to 80.
 # port_http_ping = 80
 region = "us-east-1"
@@ -46,7 +46,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = true
 is_mtls_enabled = false
 

--- a/xks-axum/configuration/settings_softhsmv2.toml
+++ b/xks-axum/configuration/settings_softhsmv2.toml
@@ -47,8 +47,7 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
-is_tls_enabled = true
+is_tls_enabled = false
 is_mtls_enabled = false
 
 # (Optional) secondary authorization used

--- a/xks-axum/configuration/settings_softhsmv2_osx.toml
+++ b/xks-axum/configuration/settings_softhsmv2_osx.toml
@@ -48,7 +48,6 @@ rotation_kind = "HOURLY"
 [security]
 # is_sigv4_auth_enabled must be set to true for production.
 is_sigv4_auth_enabled = true
-# is_tls_enabled must be set to true for production.
 is_tls_enabled = false
 is_mtls_enabled = false
 

--- a/xks-axum/rust-pkcs11/src/lib.rs
+++ b/xks-axum/rust-pkcs11/src/lib.rs
@@ -399,7 +399,7 @@ impl Ctx {
         }
     }
 
-    pub fn new_and_initialize<P>(filename: P) -> Result<Ctx, Error>
+    pub unsafe fn new_and_initialize<P>(filename: P) -> Result<Ctx, Error>
     where
         P: AsRef<Path>,
     {
@@ -428,11 +428,11 @@ impl Ctx {
         }
     }
 
-    pub fn initialize(&mut self, init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
+    pub unsafe fn initialize(&mut self, mut init_args: Option<CK_C_INITIALIZE_ARGS>) -> Result<(), Error> {
         self.not_initialized()?;
         // if no args are specified, library expects NULL
-        let init_args = match init_args {
-            Some(mut args) => &mut args,
+        let init_args = match &mut init_args {
+            Some(args) => args,
             None => ptr::null_mut(),
         };
         match (self.C_Initialize)(init_args) {

--- a/xks-axum/rust-pkcs11/src/types.rs
+++ b/xks-axum/rust-pkcs11/src/types.rs
@@ -1627,15 +1627,15 @@ pub type CK_FUNCTION_LIST_PTR_PTR = *mut CK_FUNCTION_LIST_PTR;
 
 /// CK_CREATEMUTEX is an application callback for creating a
 /// mutex object
-pub type CK_CREATEMUTEX = Option<extern "C" fn(CK_VOID_PTR_PTR) -> CK_RV>;
+pub type CK_CREATEMUTEX = Option<unsafe extern "C" fn(CK_VOID_PTR_PTR) -> CK_RV>;
 /// CK_DESTROYMUTEX is an application callback for destroying a
 /// mutex object
-pub type CK_DESTROYMUTEX = Option<extern "C" fn(CK_VOID_PTR) -> CK_RV>;
+pub type CK_DESTROYMUTEX = Option<unsafe extern "C" fn(CK_VOID_PTR) -> CK_RV>;
 /// CK_LOCKMUTEX is an application callback for locking a mutex
-pub type CK_LOCKMUTEX = Option<extern "C" fn(CK_VOID_PTR) -> CK_RV>;
+pub type CK_LOCKMUTEX = Option<unsafe extern "C" fn(CK_VOID_PTR) -> CK_RV>;
 /// CK_UNLOCKMUTEX is an application callback for unlocking a
 /// mutex
-pub type CK_UNLOCKMUTEX = Option<extern "C" fn(CK_VOID_PTR) -> CK_RV>;
+pub type CK_UNLOCKMUTEX = Option<unsafe extern "C" fn(CK_VOID_PTR) -> CK_RV>;
 
 cryptoki_aligned! {
   /// CK_C_INITIALIZE_ARGS provides the optional arguments to

--- a/xks-axum/src/xks_proxy/handlers/testings/encrypt_test.rs
+++ b/xks-axum/src/xks_proxy/handlers/testings/encrypt_test.rs
@@ -21,7 +21,7 @@ use crate::xks_proxy::pkcs11::pkcs11_error_string;
 #[allow(dead_code)]
 fn test_encrypt_init() {
     let path_buf = PathBuf::from("/opt/cloudhsm/lib/libcloudhsm_pkcs11.so");
-    let ctx = Ctx::new_and_initialize(path_buf).unwrap();
+    let ctx = unsafe { Ctx::new_and_initialize(path_buf).unwrap() };
     let slot_ids = ctx.get_slot_list(false).unwrap();
     println!("slot_ids: {:?}", slot_ids);
 

--- a/xks-axum/src/xks_proxy/pkcs11.rs
+++ b/xks-axum/src/xks_proxy/pkcs11.rs
@@ -3,32 +3,36 @@
 
 extern crate pkcs11 as rust_pkcs11;
 
+use std::cell::Cell;
 use std::path::PathBuf;
+use std::ptr;
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
+use pkcs11::types::{CK_VOID_PTR, CK_VOID_PTR_PTR};
 use rust_pkcs11::types::{
-    CKF_RW_SESSION, CKF_SERIAL_SESSION, CKK_ACTI, CKK_AES, CKK_ARIA, CKK_BATON, CKK_BLOWFISH,
-    CKK_CAMELLIA, CKK_CAST, CKK_CAST128, CKK_CAST3, CKK_CDMF, CKK_DES, CKK_DES2, CKK_DES3, CKK_DH,
-    CKK_DSA, CKK_EC, CKK_GENERIC_SECRET, CKK_GOST28147, CKK_GOSTR3410, CKK_GOSTR3411, CKK_HOTP,
-    CKK_IDEA, CKK_JUNIPER, CKK_KEA, CKK_MD5_HMAC, CKK_RC2, CKK_RC4, CKK_RC5, CKK_RIPEMD128_HMAC,
-    CKK_RIPEMD160_HMAC, CKK_RSA, CKK_SECURID, CKK_SEED, CKK_SHA224_HMAC, CKK_SHA256_HMAC,
-    CKK_SHA384_HMAC, CKK_SHA512_HMAC, CKK_SHA_1_HMAC, CKK_SKIPJACK, CKK_TWOFISH,
-    CKK_VENDOR_DEFINED, CKK_X9_42_DH, CKR_ACTION_PROHIBITED, CKR_ARGUMENTS_BAD,
-    CKR_ATTRIBUTE_READ_ONLY, CKR_ATTRIBUTE_SENSITIVE, CKR_ATTRIBUTE_TYPE_INVALID,
-    CKR_ATTRIBUTE_VALUE_INVALID, CKR_BUFFER_TOO_SMALL, CKR_CANCEL, CKR_CANT_LOCK,
-    CKR_CRYPTOKI_ALREADY_INITIALIZED, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_CURVE_NOT_SUPPORTED,
-    CKR_DATA_INVALID, CKR_DATA_LEN_RANGE, CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
-    CKR_DOMAIN_PARAMS_INVALID, CKR_ENCRYPTED_DATA_INVALID, CKR_ENCRYPTED_DATA_LEN_RANGE,
-    CKR_EXCEEDED_MAX_ITERATIONS, CKR_FIPS_SELF_TEST_FAILED, CKR_FUNCTION_CANCELED,
-    CKR_FUNCTION_FAILED, CKR_FUNCTION_NOT_PARALLEL, CKR_FUNCTION_NOT_SUPPORTED,
-    CKR_FUNCTION_REJECTED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_INFORMATION_SENSITIVE,
-    CKR_KEY_CHANGED, CKR_KEY_FUNCTION_NOT_PERMITTED, CKR_KEY_HANDLE_INVALID, CKR_KEY_INDIGESTIBLE,
-    CKR_KEY_NEEDED, CKR_KEY_NOT_NEEDED, CKR_KEY_NOT_WRAPPABLE, CKR_KEY_SIZE_RANGE,
-    CKR_KEY_TYPE_INCONSISTENT, CKR_KEY_UNEXTRACTABLE, CKR_LIBRARY_LOAD_FAILED,
-    CKR_MECHANISM_INVALID, CKR_MECHANISM_PARAM_INVALID, CKR_MUTEX_BAD, CKR_MUTEX_NOT_LOCKED,
-    CKR_NEED_TO_CREATE_THREADS, CKR_NEW_PIN_MODE, CKR_NEXT_OTP, CKR_NO_EVENT,
+    CKF_OS_LOCKING_OK, CKF_RW_SESSION, CKF_SERIAL_SESSION, CKK_ACTI, CKK_AES, CKK_ARIA, CKK_BATON,
+    CKK_BLOWFISH, CKK_CAMELLIA, CKK_CAST, CKK_CAST128, CKK_CAST3, CKK_CDMF, CKK_DES, CKK_DES2,
+    CKK_DES3, CKK_DH, CKK_DSA, CKK_EC, CKK_GENERIC_SECRET, CKK_GOST28147, CKK_GOSTR3410,
+    CKK_GOSTR3411, CKK_HOTP, CKK_IDEA, CKK_JUNIPER, CKK_KEA, CKK_MD5_HMAC, CKK_RC2, CKK_RC4,
+    CKK_RC5, CKK_RIPEMD128_HMAC, CKK_RIPEMD160_HMAC, CKK_RSA, CKK_SECURID, CKK_SEED,
+    CKK_SHA224_HMAC, CKK_SHA256_HMAC, CKK_SHA384_HMAC, CKK_SHA512_HMAC, CKK_SHA_1_HMAC,
+    CKK_SKIPJACK, CKK_TWOFISH, CKK_VENDOR_DEFINED, CKK_X9_42_DH, CKR_ACTION_PROHIBITED,
+    CKR_ARGUMENTS_BAD, CKR_ATTRIBUTE_READ_ONLY, CKR_ATTRIBUTE_SENSITIVE,
+    CKR_ATTRIBUTE_TYPE_INVALID, CKR_ATTRIBUTE_VALUE_INVALID, CKR_BUFFER_TOO_SMALL, CKR_CANCEL,
+    CKR_CANT_LOCK, CKR_CRYPTOKI_ALREADY_INITIALIZED, CKR_CRYPTOKI_NOT_INITIALIZED,
+    CKR_CURVE_NOT_SUPPORTED, CKR_DATA_INVALID, CKR_DATA_LEN_RANGE, CKR_DEVICE_ERROR,
+    CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED, CKR_DOMAIN_PARAMS_INVALID, CKR_ENCRYPTED_DATA_INVALID,
+    CKR_ENCRYPTED_DATA_LEN_RANGE, CKR_EXCEEDED_MAX_ITERATIONS, CKR_FIPS_SELF_TEST_FAILED,
+    CKR_FUNCTION_CANCELED, CKR_FUNCTION_FAILED, CKR_FUNCTION_NOT_PARALLEL,
+    CKR_FUNCTION_NOT_SUPPORTED, CKR_FUNCTION_REJECTED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+    CKR_INFORMATION_SENSITIVE, CKR_KEY_CHANGED, CKR_KEY_FUNCTION_NOT_PERMITTED,
+    CKR_KEY_HANDLE_INVALID, CKR_KEY_INDIGESTIBLE, CKR_KEY_NEEDED, CKR_KEY_NOT_NEEDED,
+    CKR_KEY_NOT_WRAPPABLE, CKR_KEY_SIZE_RANGE, CKR_KEY_TYPE_INCONSISTENT, CKR_KEY_UNEXTRACTABLE,
+    CKR_LIBRARY_LOAD_FAILED, CKR_MECHANISM_INVALID, CKR_MECHANISM_PARAM_INVALID, CKR_MUTEX_BAD,
+    CKR_MUTEX_NOT_LOCKED, CKR_NEED_TO_CREATE_THREADS, CKR_NEW_PIN_MODE, CKR_NEXT_OTP, CKR_NO_EVENT,
     CKR_OBJECT_HANDLE_INVALID, CKR_OK, CKR_OPERATION_ACTIVE, CKR_OPERATION_NOT_INITIALIZED,
     CKR_PIN_EXPIRED, CKR_PIN_INCORRECT, CKR_PIN_INVALID, CKR_PIN_LEN_RANGE, CKR_PIN_LOCKED,
     CKR_PIN_TOO_WEAK, CKR_PUBLIC_KEY_INVALID, CKR_RANDOM_NO_RNG, CKR_RANDOM_SEED_NOT_SUPPORTED,
@@ -42,7 +46,8 @@ use rust_pkcs11::types::{
     CKR_USER_ANOTHER_ALREADY_LOGGED_IN, CKR_USER_NOT_LOGGED_IN, CKR_USER_PIN_NOT_INITIALIZED,
     CKR_USER_TOO_MANY_TYPES, CKR_USER_TYPE_INVALID, CKR_VENDOR_DEFINED, CKR_WRAPPED_KEY_INVALID,
     CKR_WRAPPED_KEY_LEN_RANGE, CKR_WRAPPING_KEY_HANDLE_INVALID, CKR_WRAPPING_KEY_SIZE_RANGE,
-    CKR_WRAPPING_KEY_TYPE_INCONSISTENT, CKU_USER, CK_KEY_TYPE, CK_RV, CK_SESSION_HANDLE,
+    CKR_WRAPPING_KEY_TYPE_INCONSISTENT, CKU_USER, CK_C_INITIALIZE_ARGS, CK_KEY_TYPE, CK_RV,
+    CK_SESSION_HANDLE,
 };
 use rust_pkcs11::Ctx;
 use tracing::instrument;
@@ -51,11 +56,83 @@ use crate::{settings, SETTINGS};
 
 const P11_CONTEXT_READ_FAILURE: &str = "Failed to acquire pkcs11 context";
 
+// https://stackoverflow.com/questions/69350600/how-to-reconcile-rust-mutex-and-c-caller-supplied-locking-mechanisms
+
+#[repr(C)]
+struct MutexContainer {
+    mutex: Mutex<()>,
+    guard: Cell<Option<MutexGuard<'static, ()>>>,
+}
+
+unsafe extern "C" fn create_mutex_container(ppcontainer: CK_VOID_PTR_PTR) -> CK_RV {
+    *ppcontainer = Box::into_raw(Box::new(MutexContainer {
+        mutex: Mutex::new(()),
+        guard: Cell::new(None),
+    }))
+    .cast();
+    tracing::trace!("create_mutex_container: *ppcontainer: {:?}", *ppcontainer);
+    CKR_OK
+}
+
+unsafe extern "C" fn destroy_mutex_container(pcontainer: CK_VOID_PTR) -> CK_RV {
+    tracing::trace!("destroy_mutex_container: pmutex_container: {pcontainer:?}");
+    unlock_mutex(pcontainer);
+    drop(Box::from_raw(pcontainer.cast::<MutexContainer>()));
+    CKR_OK
+}
+
+unsafe extern "C" fn lock_mutex(pcontainer: CK_VOID_PTR) -> CK_RV {
+    tracing::trace!("lock_mutex: pmutex_container: {pcontainer:?}");
+    let container: &MutexContainer = &*pcontainer.cast();
+    match container.mutex.lock() {
+        Ok(guard) => {
+            if let Some(existing) = container.guard.take() {
+                tracing::error!("pmutex_container {pcontainer:?} already locked: existing={existing:?}, guard={guard:?}");
+                panic!("An existing guard should never be found if a lock is successful.  Abort to avoid potential race conditions and corrupted data.");
+            }
+            container.guard.set(Some(guard));
+            CKR_OK
+        }
+        Err(err) => {
+            tracing::warn!("lock_mutex failure: {err}");
+            CKR_MUTEX_BAD
+        }
+    }
+}
+
+unsafe extern "C" fn unlock_mutex(pcontainer: CK_VOID_PTR) -> CK_RV {
+    tracing::trace!("unlock_mutex: pmutex_container: {pcontainer:?}");
+    let container: &MutexContainer = &*pcontainer.cast();
+    let guard = container.guard.take();
+    if guard.is_none() {
+        CKR_MUTEX_NOT_LOCKED
+    } else {
+        std::mem::drop(guard);
+        CKR_OK
+    }
+}
+
 lazy_static! {
-    pub static ref P11_CONTEXT: RwLock<Ctx> = RwLock::new(
-        Ctx::new_and_initialize(crate::xks_proxy::pkcs11::pkcs11_module_name())
-            .expect("failed to create and initialize the pkcs11 context")
-    );
+    pub static ref P11_CONTEXT: RwLock<Ctx> = RwLock::new({
+        let filename = crate::xks_proxy::pkcs11::pkcs11_module_name();
+        let mut ctx = Ctx::new(filename).expect("Failed to create the pkcs11 context");
+        let args = CK_C_INITIALIZE_ARGS {
+            flags: CKF_OS_LOCKING_OK,
+            CreateMutex: Some(create_mutex_container),
+            DestroyMutex: Some(destroy_mutex_container),
+            LockMutex: Some(lock_mutex),
+            UnlockMutex: Some(unlock_mutex),
+            pReserved: ptr::null_mut(),
+        };
+        unsafe {
+            if let Err(err) = ctx.initialize(Some(args)) {
+                tracing::warn!("Failed to initialize the pkcs11 context with mutex callback functions due to {}.  Retrying initialization without callback functions.", err);
+                ctx.initialize(None)
+                    .expect("Failed to initialize the pkcs11 context");
+            }
+        }
+        ctx
+    });
 }
 
 #[instrument(skip_all)]
@@ -334,4 +411,11 @@ pub fn is_ckr_fatal(pkcs11_err: &rust_pkcs11::errors::Error) -> bool {
     } else {
         false
     }
+}
+
+pub fn is_ckr_device_error(pkcs11_err: &rust_pkcs11::errors::Error) -> bool {
+    matches!(
+        pkcs11_err,
+        rust_pkcs11::errors::Error::Pkcs11(CKR_DEVICE_ERROR)
+    )
 }


### PR DESCRIPTION
*Issue #, if available:*

Prior to this change, we experienced crashes when testing `SoftHSMv2` under concurrent loads.  I was able to reproduce the crash with a test simulation, and created the branch `main_concurrent` that basically generates a number of concurrent requests for every external request to simulate concurrent loads that can easily lead to a crash.)
* I realized `SoftHSMv2` depended on the caller to pass in the necessary mutex function pointers via the [PKCS#11 interface](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html) during initialization in order to provide the necessary safety in a concurrent environment.
* After providing the mutex function pointers, however, the crash still persisted.  Upon further investigation, we discovered the crash was due to a bug in the `pkcs11 crate` which inadvertently passed in the wrong memory address (in binding a local variable in a `match` statement) to `SoftHSMv2` via the `PKCS#11` C interface.
* After fixing the bug in `pkcs11 crate`, there were still crashes but limited to when the `PKCS#11` sessions were closed by `SoftHSMv2`.  Using `gdb`, I realized a session was first removed "permanently" from the pool before being closed.  However, removing the session permanently from the pool would cause the memory to get de-allocated by Rust (as it went out of scope),  hence causing the subsequent close operation by `SoftHSMv2` to crash.   The test simulation no longer crashed after this was fixed (by changing the order of operations).

*Description of changes:*
Enable the use of `SoftHSMv2` in a concurrent environment without crashing, upgrading to `v3.1.2`

1. Initialize `PKCS#11` context with lock functions and upon failure would retry `PKCS#11` initialization without callback functions
1. Fix memory corruption bugs in `pkcs11 crate` in context initialization (Special thanks to sraux@amazon.com)
1. Fix memory access error by closing session before removing from the pool
1. Mark `Ctx::new_and_initialize` and `Ctx::initialize as unsafe`
1. Mark callback functions passed to PKCS#11 unsafe
1. Misc minor changes to tidy up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

