### PR TITLE
Bug fix resetting PKCS#11 context

### DIFF
--- a/xks-axum/src/xks_proxy/mod.rs
+++ b/xks-axum/src/xks_proxy/mod.rs
@@ -4,7 +4,6 @@
 extern crate pkcs11 as rust_pkcs11;
 use std::time::Duration;
 
-use ::pkcs11::Ctx;
 use deadpool::unmanaged::{Object, Pool, PoolConfig};
 use http::StatusCode;
 use lazy_static::lazy_static;
@@ -197,10 +196,7 @@ fn reset_p11_context() {
         );
     }
     tracing::warn!("Creating and initializing a new pkcs11 context");
-    *ctx_write_guard = unsafe {
-        Ctx::new_and_initialize(crate::xks_proxy::pkcs11::pkcs11_module_name())
-            .expect("failed to create and initialize the pkcs11 context")
-    };
+    *ctx_write_guard = unsafe { pkcs11::new_and_initialize() };
     tracing::info!("Done resetting pkcs11 context");
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During reset of the PKCS#11 context, I missed passing the callback functions to the initialization function, thus causing `SoftHSMv2` to crash after.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

