### PR TITLE
Upgrade base64 crate from 0.13.x to 0.20.x

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.6", features = ["headers"] }
 axum-server = { version = "0.4", features = ["tls-rustls"] }
 axum-macros = "0.3"
 
-base64 = "0.13"
+base64 = "0.20"
 bytes = "1.1"
 chrono = "0.4"
 const_format = "0.2"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/marshallpierce/rust-base64/issues/189

*Description of changes:*

Passed all tests using `aws-kms-xksproxy-test-client`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

