### PR TITLE
Fix clippy warnings and upgrade toml crate from 0.6.x to 0.7.x

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0"
 serde_with = "2.0"
 
 tokio = { version = "1", features = ["rt-multi-thread"]}
-toml = "0.6"
+toml = "0.7"
 tonic = { version = "0.8", features = ["transport", "tls"] }
 tower-http = { version = "0.3", features = ["trace"] }
 

--- a/xks-axum/src/tls.rs
+++ b/xks-axum/src/tls.rs
@@ -102,7 +102,7 @@ fn pki_error(error: webpki::Error) -> rustls::Error {
         UnsupportedSignatureAlgorithm | UnsupportedSignatureAlgorithmForPublicKey => {
             rustls::Error::InvalidCertificateSignatureType
         }
-        e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
+        e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
     }
 }
 

--- a/xks-axum/src/xks_proxy/handlers/get_health_status.rs
+++ b/xks-axum/src/xks_proxy/handlers/get_health_status.rs
@@ -152,7 +152,7 @@ async fn do_enact(
         xksProxyFleetSize: 1,
         xksProxyVendor: "AWS-KMS".to_string(),
         xksProxyModel: "RustXksProxy".to_string(),
-        ekmVendor: format!("{} (serial number: {})", manufacturer_id, serial_number),
+        ekmVendor: format!("{manufacturer_id} (serial number: {serial_number})"),
         ekmFleetDetails: vec![EkmFleetDetails {
             id: label.to_string(),
             model: format!(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Apparently the latest cargo 1.67.0 is stricter on some formatting styles, emitting warnings upon `cargo clippy`.  This PR fixes that.  
2. The `toml` crate has just upgraded to `0.7.x` so including it as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Warnings on `cargo clippy` prior to this change:
```
warning: variables can be used directly in the `format!` string
   --> src/tls.rs:105:52
    |
105 |         e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `#[warn(clippy::uninlined_format_args)]` on by default
help: change this to
    |
105 -         e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {}", e)),
105 +         e => rustls::Error::InvalidCertificateData(format!("invalid peer certificate: {e}")),
    |

warning: variables can be used directly in the `format!` string
   --> src/xks_proxy/handlers/get_health_status.rs:155:20
    |
155 |         ekmVendor: format!("{} (serial number: {})", manufacturer_id, serial_number),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
155 -         ekmVendor: format!("{} (serial number: {})", manufacturer_id, serial_number),
155 +         ekmVendor: format!("{manufacturer_id} (serial number: {serial_number})"),
    |

warning: `xks-proxy` (bin "xks-proxy") generated 2 warnings
```
# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

