### PR TITLE
Switch to aws-lc-rs

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -34,7 +34,7 @@ oso-derive = "0.26"
 parking_lot = "0.12"
 pkcs11 = "0.5.0"
 
-ring = "0.16"
+aws-lc-rs = "1.1.0"
 
 rustls = "0.20"
 rustls-pemfile = "1.0"

--- a/xks-axum/src/xks_proxy/handlers/mod.rs
+++ b/xks-axum/src/xks_proxy/handlers/mod.rs
@@ -22,7 +22,7 @@ use pkcs11::types::{
     CK_GCM_PARAMS, CK_GCM_PARAMS_PTR, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_TRUE,
     CK_ULONG, CK_VOID_PTR,
 };
-use ring::digest;
+use aws_lc_rs::digest;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use tracing::instrument;

--- a/xks-axum/src/xks_proxy/handlers/mod.rs
+++ b/xks-axum/src/xks_proxy/handlers/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use std::mem;
 use std::time::Duration;
 
+use aws_lc_rs::digest;
 use axum::body::HttpBody;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::FromRequest;
@@ -22,7 +23,6 @@ use pkcs11::types::{
     CK_GCM_PARAMS, CK_GCM_PARAMS_PTR, CK_MECHANISM, CK_OBJECT_HANDLE, CK_SESSION_HANDLE, CK_TRUE,
     CK_ULONG, CK_VOID_PTR,
 };
-use aws_lc_rs::digest;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use tracing::instrument;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This switches the dependency on `ring` to a dependency on [`aws-lc-rs`](https://crates.io/crates/aws-lc-rs).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

