### PR TITLE
Update Dockerfile to use softhsm2 instead of softhsm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p $HOME/aws-kms-xks-proxy
 COPY ./xks-axum $HOME/aws-kms-xks-proxy/xks-axum
 
 RUN apt-get update -y
-RUN apt-get install -y softhsm opensc curl build-essential
+RUN apt-get install -y softhsm2 opensc curl build-essential
 
 RUN softhsm2-util --init-token --slot 0 --label "xks-proxy" --so-pin 1234 --pin 1234
 RUN pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \


### PR DESCRIPTION
*Description of changes:*
* Current build is failing due to softhsmv2 not being used during

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

