### PR TITLE
Lock scratchstack-aws-signature to 0.10.5

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -39,7 +39,7 @@ ring = "0.16"
 rustls = "0.20"
 rustls-pemfile = "1.0"
 
-scratchstack-aws-signature = "0.10"
+scratchstack-aws-signature = "=0.10.5"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"


### PR DESCRIPTION

*Issue #, if available:*

Building this crate, either in docker or locally, causes a mismatch of http::request::Parts types in src/xks_proxy/sigv4.rs:

```
    let sigv4_req = Sigv4Request::from_http_request_parts(&parts, body_as_vec_u8);
        |                     ------------------------------------- ^^^^^^ expected http::request::Parts, found a different http::request::Parts
        |                     |
        |                     arguments to this function are incorrect
        |
        = note: http::request::Parts and http::request::Parts have similar names, but are actually distinct types
    note: http::request::Parts is defined in crate http
       --> /Users/me/.cargo/registry/src/index.crates.io-6f17d22bba15001f/http-0.2.12/src/request.rs:166:1
        |
    166 | pub struct Parts {
        | ^^^^^^^^^^^^^^^^
    note: http::request::Parts is defined in crate http
       --> /Users/me/.cargo/registry/src/index.crates.io-6f17d22bba15001f/http-1.1.0/src/request.rs:168:1
        |
    168 | pub struct Parts {
        | ^^^^^^^^^^^^^^^^
        = note: perhaps two different versions of crate http are being used?
    note: associated function defined here
       --> /Users/me/.cargo/registry/src/index.crates.io-6f17d22bba15001f/scratchstack-aws-signature-0.10.6/src/signature.rs:762:12
        |
    762 |     pub fn from_http_request_parts(parts: &Parts, body: Option<Vec<u8>>) -> Self {
        |            ^^^^^^^^^^^^^^^^^^^^^^^

    For more information about this error, try rustc --explain E0308.
    error: could not compile xks-proxy (bin "xks-proxy") due to 1 previous error
```

I'm not super familiar with rust but it looks like this is caused by the http dependency of scratchstack-aws-signature being updated from ^0.2 to ^1.0 for the 0.10.6 release:

  https://github.com/dacut/scratchstack-aws-signature/commit/e77f6150f4af192dd35ee21c47ae30ac7c46e235


*Description of changes:*

This just locks scratchstack-aws-signature to 0.10.5.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

