### PR TITLE
Lock scratchstack-aws-signature version

### DIFF
--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -39,7 +39,7 @@ ring = "0.16"
 rustls = "0.20"
 rustls-pemfile = "1.0"
 
-scratchstack-aws-signature = "0.10"
+scratchstack-aws-signature = "=0.10.5"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"


### PR DESCRIPTION
*Description of changes:*
* Lock scratchstack-aws-signature version to avoid build failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


