### PR TITLE
lock scratchstack-aws-signature & rust version to fix compilation and runtime issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@
 FROM ubuntu as builder
 
 ENV HOME=/root
+ENV RUST_VERSION=1.75.0
 RUN mkdir -p $HOME/aws-kms-xks-proxy
 COPY ./xks-axum $HOME/aws-kms-xks-proxy/xks-axum
 
@@ -17,8 +18,8 @@ RUN pkcs11-tool --module /usr/lib/softhsm/libsofthsm2.so \
                 --token-label xks-proxy --login --login-type user \
                 --keygen --id F0 --label foo --key-type aes:32 \
                 --pin 1234
-
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl "https://static.rust-lang.org/dist/rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz" -o rust.tar.gz && \
+    tar -xvf rust.tar.gz && cd "rust-$RUST_VERSION-x86_64-unknown-linux-gnu" && ./install.sh
 ENV PATH="$HOME/.cargo/bin:$PATH"
 
 RUN mkdir -p /var/local/xks-proxy/.secret

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -39,7 +39,7 @@ ring = "0.16"
 rustls = "0.20"
 rustls-pemfile = "1.0"
 
-scratchstack-aws-signature = "0.10"
+scratchstack-aws-signature = "=0.10.5"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"

--- a/xks-axum/Cargo.toml
+++ b/xks-axum/Cargo.toml
@@ -39,7 +39,7 @@ ring = "0.16"
 rustls = "0.20"
 rustls-pemfile = "1.0"
 
-scratchstack-aws-signature = "=0.10.5"
+scratchstack-aws-signature = "=0.10.4"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"


### PR DESCRIPTION
*Issue #, if available:* [#49 ](https://github.com/aws-samples/aws-kms-xks-proxy/issues/49) and https://github.com/aws-samples/aws-kms-xks-proxy/issues/53

*Description of changes:*
Tagged rust version to 1.75.0 and scratchstack-aws-signature version to `=0.10.5` to fix the compilation issue and runtime issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

